### PR TITLE
Add prealloc buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "fawkes-crypto"
-version = "4.3.3"
+version = "4.3.4"
 dependencies = [
  "bit-vec",
  "blake2-rfc_bellman_edition",

--- a/fawkes-crypto/Cargo.toml
+++ b/fawkes-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fawkes-crypto"
-version = "4.3.3"
+version = "4.3.4"
 authors = ["Igor Gulamov <igor.gulamov@gmail.com>"]
 description = "zk-SNARK circuit building framework"
 readme = "README.md"

--- a/fawkes-crypto/src/constants.rs
+++ b/fawkes-crypto/src/constants.rs
@@ -1,2 +1,3 @@
 pub const PERSONALIZATION: &'static [u8; 8] = b"__fawkes";
 pub const SEED_EDWARDS_G: &'static [u8] = b"edwards_g";
+pub const PREALLOC_SIZE: usize = 10;

--- a/fawkes-crypto/src/native/poseidon.rs
+++ b/fawkes-crypto/src/native/poseidon.rs
@@ -60,6 +60,7 @@ fn sigma<Fr: PrimeField>(a: Num<Fr>) -> Num<Fr> {
 fn mix<Fr: PrimeField>(state: &mut [Num<Fr>], params: &PoseidonParams<Fr>) {
     let statelen = state.len();
 
+    // Don't allocate memory in heap if statelen is less or equal to PREALLOC_SIZE
     let mut arr: [Num<Fr>; PREALLOC_SIZE] = [Num::ZERO; PREALLOC_SIZE];
     let mut vec: Vec<Num<Fr>> = Vec::new();
     let new_state = match statelen {
@@ -97,6 +98,14 @@ fn perm<Fr: PrimeField>(state: &mut [Num<Fr>], params: &PoseidonParams<Fr>) {
 }
 
 pub fn poseidon<Fr: PrimeField>(inputs: &[Num<Fr>], params: &PoseidonParams<Fr>) -> Num<Fr> {
+    let n_inputs = inputs.len();
+    assert!(
+        n_inputs < params.t,
+        "number of inputs should be less or equal than t"
+    );
+    assert!(n_inputs > 0, "number of inputs should be positive nonzero");
+
+    // Don't allocate memory in heap if statelen is less or equal to PREALLOC_SIZE
     let mut arr: [Num<Fr>; PREALLOC_SIZE] = [Num::ZERO; PREALLOC_SIZE];
     let mut vec: Vec<Num<Fr>> = Vec::new();
     let state = match params.t {
@@ -106,13 +115,6 @@ pub fn poseidon<Fr: PrimeField>(inputs: &[Num<Fr>], params: &PoseidonParams<Fr>)
             &mut vec[..]
         }
     };
-    
-    let n_inputs = inputs.len();
-    assert!(
-        n_inputs < params.t,
-        "number of inputs should be less or equal than t"
-    );
-    assert!(n_inputs > 0, "number of inputs should be positive nonzero");
     
     (0..n_inputs).for_each(|i| state[i] = inputs[i]);
 


### PR DESCRIPTION
Allocations during poseidon hash computation lead to extremely slow performance on Mac M1. This PR tries to fix it by introducing preallocated buffer.
![image](https://user-images.githubusercontent.com/17165678/208053411-a3463379-0593-42b7-9a36-9529a6fa03b9.png)
