### PR TITLE
Minor fixes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[net]
-git-fetch-with-cli = true # phase2-bn254 is a private repo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "fawkes-crypto-bellman_ce"
 version = "0.3.5"
-source = "git+ssh://git@github.com/zkBob/phase2-bn254.git?branch=multicore-wasm#23fc4b6fd729e57785483d8dbebaeee712389803"
+source = "git+https://github.com/zkBob/phase2-bn254?branch=multicore-wasm#f484dbe81e1fd5707de4168a928c5a51e0389add"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "fawkes-crypto-pairing_ce"
 version = "0.18.1"
-source = "git+ssh://git@github.com/zkBob/phase2-bn254.git?branch=multicore-wasm#23fc4b6fd729e57785483d8dbebaeee712389803"
+source = "git+https://github.com/zkBob/phase2-bn254?branch=multicore-wasm#f484dbe81e1fd5707de4168a928c5a51e0389add"
 dependencies = [
  "byteorder",
  "ff_ce",

--- a/fawkes-crypto/Cargo.toml
+++ b/fawkes-crypto/Cargo.toml
@@ -34,7 +34,7 @@ package = "blake2-rfc_bellman_edition"
 [dependencies.bellman]
 version = "0.3.4"
 package = "fawkes-crypto-bellman_ce"
-git = "ssh://git@github.com/zkBob/phase2-bn254.git"
+git = "https://github.com/zkBob/phase2-bn254"
 branch = "multicore-wasm"
 optional = true
 

--- a/fawkes-crypto/src/core/sizedvec.rs
+++ b/fawkes-crypto/src/core/sizedvec.rs
@@ -7,6 +7,8 @@ use std::{
 };
 
 
+use serde::de::Error;
+
 #[cfg(feature = "borsh_support")]
 use crate::borsh::{BorshSerialize, BorshDeserialize};
 
@@ -40,7 +42,12 @@ impl<T: Serialize, const L: usize> Serialize for SizedVec<T, L> {
 #[cfg(feature = "serde_support")]
 impl<'de, T: Deserialize<'de>, const L: usize> Deserialize<'de> for SizedVec<T, L> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<SizedVec<T, L>, D::Error> {
-        Vec::<T>::deserialize(deserializer).map(|v| SizedVec::<T, L>::from_iter(v))
+        let v = Vec::<T>::deserialize(deserializer)?;
+        if v.len() != L {
+            Err(Error::invalid_length(v.len(), &L.to_string().as_str()))
+        } else {
+            Ok(SizedVec::<T, L>::from_iter(v))
+        }
     }
 }
 


### PR DESCRIPTION
1. Replace `ssh` with `https` in `phase2-bn254` dependency. Since `phase2-bn254` is public now `ssh` is not necessary. `ssh` is not convenient for building images.
2. Prevent panic during SizedVec deserialization. It is necessary to handle bad requests in `zkbob-prover` properly. 