### PR TITLE
Add compress, decompress_unchecked, and is_in_prime_subgroup methods

### DIFF
--- a/fawkes-crypto/tests/ecc.rs
+++ b/fawkes-crypto/tests/ecc.rs
@@ -1,0 +1,39 @@
+use fawkes_crypto::{
+    native::ecc::*,
+    ff_uint::Num,
+    engines::bn256::{Fr, JubJubBN256},
+    rand::thread_rng,
+};
+
+
+#[test]
+fn test_compress_decompress() {
+    let mut rng = thread_rng();
+    let params = JubJubBN256::new();
+
+    let p = EdwardsPoint::<Fr>::rand(&mut rng, &params).mul(Num::from(8), &params);
+    let p_bytes = p.compress(&params);
+    let p_2 = EdwardsPoint::<Fr>::decompress_unchecked(p_bytes, &params).unwrap();
+    assert_eq!(p, p_2);
+    assert!(p_2.is_in_prime_subgroup(&params))
+}
+
+
+#[test]
+fn test_decompress_subgroup_decompress() {
+    let mut rng = thread_rng();
+    let params = JubJubBN256::new();
+
+    let p = EdwardsPoint::<Fr>::rand(&mut rng, &params).mul(Num::from(8), &params);
+
+    let (p_1, is_in_prime_subgroup_1) = {
+        let p_bytes = p.compress(&params);
+        let p = EdwardsPoint::<Fr>::decompress_unchecked(p_bytes, &params).unwrap();
+        (p, p.is_in_prime_subgroup(&params))
+    };
+
+    let p_2 = {
+        EdwardsPoint::<Fr>::subgroup_decompress(p.x, &params)
+    };
+    assert!(!is_in_prime_subgroup_1 && p_2.is_none() || is_in_prime_subgroup_1 && p_1 == p_2.unwrap())
+}


### PR DESCRIPTION
In this PR, the following was done:
1. Implemented `EdwardPoint::compress method` that packs X coordinate and the sign of Y in 32 bytes.
2. Implemented `EdwardPoint::decompress_unchecked` method that restores the point serialized with the previous method without checking that the point is in the prime subgroup.
3. Implemented `EdwardPoint::is_in_prime_subgroup` method that checks that the point is in the prime subgroup.
4. Added unit tests that check the aforementioned methods work properly.

The reason why it could be useful is described at https://github.com/zkBob/zkbob-pool-storage/issues/2.