### PR TITLE
Replace u128 mul with u64 muls for wasm target

### DIFF
--- a/ff-uint/src/ff/mod.rs
+++ b/ff-uint/src/ff/mod.rs
@@ -13,7 +13,32 @@ pub mod traits;
 
 pub use self::arith_impl::*;
 
-mod arith_impl {
+pub mod arith_impl {
+    #[cfg(target_arch = "wasm32")]
+    #[inline(always)]
+    pub fn mul_u64(x: u64, y: u64) -> u128 {
+        // x = x_1 * 2^32 + x_0
+        let x_0 = (x as u32) as u64;
+        let x_1 = x >> 32;
+
+        // y = y_1 * 2^32 + y_0
+        let y_0 = (y as u32) as u64;
+        let y_1 = y >> 32;
+
+        let z_0 = x_0 * y_0;
+        let z_2 = x_1 * y_1;
+
+        let z_1 = u128::from(x_0 * y_1) + u128::from(x_1 * y_0);
+
+        (u128::from(z_2) << 64) + (z_1 << 32) + u128::from(z_0)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[inline(always)]
+    pub fn mul_u64(x: u64, y: u64) -> u128 {
+        (x as u128) * (y as u128)
+    }
+
     /// Calculate a - b - borrow, returning the result and modifying
     /// the borrow value.
     #[inline(always)]
@@ -40,7 +65,7 @@ mod arith_impl {
     /// and setting carry to the most significant digit.
     #[inline(always)]
     pub fn mac_with_carry(a: u64, b: u64, c: u64, carry: &mut u64) -> u64 {
-        let tmp = (u128::from(a)) + u128::from(b) * u128::from(c) + u128::from(*carry);
+        let tmp = u128::from(a) + mul_u64(b, c) + u128::from(*carry);
 
         *carry = (tmp >> 64) as u64;
 

--- a/ff-uint/src/lib.rs
+++ b/ff-uint/src/lib.rs
@@ -32,7 +32,7 @@ pub use static_assertions;
 #[macro_use]
 mod uint;
 #[macro_use]
-mod ff;
+pub mod ff;
 mod num;
 mod traits;
 

--- a/ff-uint/src/uint/macros.rs
+++ b/ff-uint/src/uint/macros.rs
@@ -76,7 +76,7 @@ macro_rules! uint_full_mul_reg {
                             if $check(me[j], carry) {
                                 let a = me[j];
 
-                                let (hi, low) = Self::split_u128(a as u128 * b as u128);
+                                let (hi, low) = Self::split_u128($crate::ff::arith_impl::mul_u64(a, b));
 
                                 let overflow = {
                                     let existing_low = &mut ret[i + j];


### PR DESCRIPTION
The reasoning behind this PR can be found in the following [issue](https://github.com/zkBob/fawkes-crypto/issues/16).